### PR TITLE
Add a `php` directive to plugin.yml

### DIFF
--- a/src/pocketmine/plugin/PluginDescription.php
+++ b/src/pocketmine/plugin/PluginDescription.php
@@ -56,6 +56,8 @@ class PluginDescription{
 	private $compatibleMcpeProtocols = [];
 	/** @var string[] */
 	private $compatibleOperatingSystems = [];
+	/** @var string[] */
+	private $compatiblePhpVersions = [];
 	/**
 	 * @var string[][]
 	 * @phpstan-var array<string, list<mixed>>
@@ -116,6 +118,7 @@ class PluginDescription{
 		$this->api = array_map("\strval", (array) ($plugin["api"] ?? []));
 		$this->compatibleMcpeProtocols = array_map("\intval", (array) ($plugin["mcpe-protocol"] ?? []));
 		$this->compatibleOperatingSystems = array_map("\strval", (array) ($plugin["os"] ?? []));
+		$this->compatiblePhpVersions = array_map("\strval", (array) ($plugin["php"] ?? []));
 
 		if(isset($plugin["commands"]) and is_array($plugin["commands"])){
 			$this->commands = $plugin["commands"];
@@ -192,6 +195,13 @@ class PluginDescription{
 	 */
 	public function getCompatibleOperatingSystems() : array{
 		return $this->compatibleOperatingSystems;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getCompatiblePhpVersions() : array{
+		return $this->compatiblePhpVersions;
 	}
 
 	/**

--- a/src/pocketmine/plugin/PluginManager.php
+++ b/src/pocketmine/plugin/PluginManager.php
@@ -269,6 +269,16 @@ class PluginManager{
 						continue;
 					}
 
+					$pluginPhpVersions = $description->getCompatiblePhpVersions();
+					$pluginCompatiblePhpVersions = array_filter($pluginPhpVersions, function(string $version) : bool{ return Utils::arePhpVersionsCompatible($version, PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "." . PHP_RELEASE_VERSION); });
+					if(count($pluginPhpVersions) > 0 and count($pluginCompatiblePhpVersions) < 1){
+						$this->server->getLogger()->error($this->server->getLanguage()->translateString("pocketmine.plugin.loadError", [
+							$name,
+							$this->server->getLanguage()->translateString("%pocketmine.plugin.incompatiblePhpVersion", [implode(", ", $pluginPhpVersions)])
+						]));
+						continue;
+					}
+
 					if(count($pluginMcpeProtocols = $description->getCompatibleMcpeProtocols()) > 0){
 						$serverMcpeProtocols = [ProtocolInfo::CURRENT_PROTOCOL];
 						if(count(array_intersect($pluginMcpeProtocols, $serverMcpeProtocols)) === 0){

--- a/src/pocketmine/utils/Utils.php
+++ b/src/pocketmine/utils/Utils.php
@@ -355,6 +355,17 @@ class Utils{
 		return $processors;
 	}
 
+	public static function arePhpVersionsCompatible(string $mainVersion, string $otherVersion) : bool{
+		$mainVersionParts = explode(".", $mainVersion);
+		$otherVersionParts = explode(".", $otherVersion);
+
+		if(count($mainVersionParts) < 2 or count($otherVersionParts) < 2){
+			throw new \InvalidArgumentException("The versions must include major and minor version!");
+		}
+
+		return $mainVersionParts[0] === $otherVersionParts[0] and $mainVersionParts[1] === $otherVersionParts[1] and (count($mainVersionParts) < 3 or count($otherVersionParts) < 3 or intval($mainVersionParts[2]) >= intval($otherVersionParts[2]));
+	}
+
 	/**
 	 * Returns a prettified hexdump
 	 */

--- a/tests/phpunit/utils/UtilsTest.php
+++ b/tests/phpunit/utils/UtilsTest.php
@@ -93,4 +93,12 @@ class UtilsTest extends TestCase{
 		//be careful with this test. The closure has to be declared on the same line as the assertion.
 		self::assertSame('closure@' . Utils::cleanPath(__FILE__) . '#L' . __LINE__, Utils::getNiceClosureName(function() : void{}));
 	}
+
+	public function testPhpVersionsCompatibility() : void{
+		self::assertTrue(Utils::arePhpVersionsCompatible("7.3", "7.3"));
+		self::assertTrue(Utils::arePhpVersionsCompatible("7.3.3", "7.3.3"));
+		self::assertTrue(Utils::arePhpVersionsCompatible("7.3.2", "7.3.3"));
+		self::assertFalse(Utils::arePhpVersionsCompatible("7.3", "7.4"));
+		self::assertFalse(Utils::arePhpVersionsCompatible("7.3.2", "7.3.1"));
+	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
It has been mentioned before (#3195) that using features from higher php versions on servers using previous versions is an issue. This PR addresses that issue by adding an optional property "php" to let plugin developers specify the compatible php versions.

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->
Closes #3195

## Translations

This PR requires translation for `pocketmine.plugin.incompatiblePhpVersion` [(#57)](https://github.com/pmmp/PocketMine-Language/pull/57)

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Adding this property to a plugin manifest is optional, it maintains BC.

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
All of these tests were done using PHP 7.3.14, I added the following properties to the plugin manifest and noted the result:
- `php: 7.3` -> Plugin loads
- `php: 7.3.14` -> Plugin loads
- `php: [7.3.15, 7.3.13]` -> Plugin doesn't load
- `php: 5.4` -> Plugin doesn't load
- `#Not specified` -> Plugin loads